### PR TITLE
Fix astroid update breaking build

### DIFF
--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -30,7 +30,7 @@ if dev_version is not None:
     version += "-dev" + str(dev_version)
 
 install_requires = [
-    "astroid>=2.3.0,<=2.5",
+    "astroid==2.3.3,<=2.5",
     "mccabe>=0.6,<0.7",
     "toml>=0.7.1",
 ]


### PR DESCRIPTION
The mysterious breaking builds as 
https://github.com/ankitects/anki/runs/624211313#step:27:1153 are happening because astroid has released a new version which is either doing nasty things or the anki code is bugged: https://github.com/PyCQA/pylint/issues/3542 - Latest update 2.5.0 broke --extension-pkg-whitelist

After merging this, the builds are only start passing after the pyenv cache of the GitHub actions will have to be reset. This can be done with this pull request: https://github.com/ankitects/anki/pull/595 - Reset the GitHub Actions cache for pyenv